### PR TITLE
Update Version in Readme to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Basic Usage
         <plugin>
           <groupId>org.jboss.jandex</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
-          <version>1.0-SNAPSHOT</version>
+          <version>1.0.1</version>
           <executions>
             <execution>
               <id>make-index</id>
@@ -40,7 +40,7 @@ If you need to process more than one directory of classes, you can specify multi
         <plugin>
           <groupId>org.jboss.jandex</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
-          <version>1.0-SNAPSHOT</version>
+          <version>1.0.1</version>
           <executions>
             <execution>
               <id>make-index</id>


### PR DESCRIPTION
The version of the plugin in the README.md is 1.0-SNAPSHOT. This is
problematic because Maven does not like snapshot plugins in release
builds. Fortunately version 1.0.1 has been released so this is not an
issue.
- update README.md
