### PR TITLE
Mark Plugin as Thread Safe

### DIFF
--- a/src/main/java/org/jboss/jandex/maven/JandexGoal.java
+++ b/src/main/java/org/jboss/jandex/maven/JandexGoal.java
@@ -21,9 +21,10 @@ import org.jboss.jandex.Indexer;
 
 /**
  * Generate a Jandex index for classes compiled as part of the current project.
- * 
+ *
  * @goal jandex
  * @phase process-classes
+ * @threadSafe
  * @author jdcasey
  */
 public class JandexGoal
@@ -33,7 +34,7 @@ public class JandexGoal
     /**
      * By default, process the classes compiled for the project. If you need to process other sets of classes, such as
      * test classes, see the "fileSets" parameter.
-     * 
+     *
      * @parameter default-value="${project.build.outputDirectory}"
      * @readonly
      */
@@ -42,7 +43,7 @@ public class JandexGoal
     /**
      * Process the classes found in these file-sets, after considering the specified includes and excludes, if any. The
      * format is: <br/>
-     * 
+     *
      * <pre>
      * <code>
      * &lt;fileSets&gt;
@@ -58,31 +59,31 @@ public class JandexGoal
      * &lt;/fileSets&gt;
      * </code>
      * </pre>
-     * 
+     *
      * <br>
      * <em>NOTE: Standard globbing expressions are supported in includes/excludes.</em>
-     * 
+     *
      * @parameter
      */
     private List<FileSet> fileSets;
 
     /**
      * If true, construct an implied file-set using the target/classes directory, and process the classes there.
-     * 
+     *
      * @parameter default-value="true"
      */
     private final boolean processDefaultFileSet = true;
 
     /**
      * Print verbose output (debug output without needing to enable -X for the whole build)
-     * 
+     *
      * @parameter default-value="false"
      */
     private boolean verbose = false;
 
     /**
      * Skip execution if set.
-     * 
+     *
      * @parameter default-value="false" expression="${jandex.skip}"
      */
     private boolean skip = true;


### PR DESCRIPTION
In order to profit from Maven 3 paralled builds the plugin has to be
marked as thread safe.

 [1] https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3
