### PR TITLE
log skip message with info instead of error

### DIFF
--- a/src/main/java/org/jboss/jandex/maven/JandexGoal.java
+++ b/src/main/java/org/jboss/jandex/maven/JandexGoal.java
@@ -151,7 +151,7 @@ public class JandexGoal
             final File dir = fileset.getDirectory();
             if ( !dir.exists() )
             {
-                getLog().error( "[SKIP] Cannot process fileset in directory: " + fileset.getDirectory()
+                getLog().info( "[SKIP] Cannot process fileset in directory: " + fileset.getDirectory()
                                     + ". Directory does not exist!" );
                 continue;
             }


### PR DESCRIPTION
The SKIP message should not be logged as error but as info.

If the plugin is configured in a parent pom, the build parent pom always logs an error which is currently none.

Logging the SKIP is OK, but it is not an error.