### PR TITLE
Upgrade to Jandex 2.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>jandex</artifactId>
-      <version>2.0.1.Final</version>
+      <version>2.0.3.Final</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
This is recommended by Weld 2.4.0.Final

    WARN: WELD-000169: Jandex cannot distinguish inner and static nested classes! Update Jandex to 2.0.3.Final version or newer to improve scanning performance.