### PR TITLE
Bump jandex to 2.1.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>jandex</artifactId>
-      <version>2.1.1.Final</version>
+      <version>2.1.2.Final</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
This version contains support for Dynamic Constants (JEP 309) which is essential for JDK 11 support