### PR TITLE
Update Jandex to 2.2.3.Final and bump to 1.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.jboss.jandex</groupId>
   <artifactId>jandex-maven-plugin</artifactId>
-  <version>1.0.9-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Jandex wrapper for Maven</name>
@@ -40,7 +40,7 @@
     </license>
   </licenses>
   
-	<issueManagement>
+  <issueManagement>
     <url>https://github.com/jdcasey/jandex-maven-plugin/issues</url>
     <system>GitHub Issues</system>
   </issueManagement>
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>jandex</artifactId>
-      <version>2.1.2.Final</version>
+      <version>2.2.3.Final</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
Resolves #19.
Version bump to 1.1.0 relates to #21.