### PR TITLE
Upgrade to Jandex 2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ target
 .classpath
 .settings/
 .project
+
+# Intellij IDEA
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.jboss.jandex</groupId>
   <artifactId>jandex-maven-plugin</artifactId>
-  <version>1.0.9-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Jandex wrapper for Maven</name>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>jandex</artifactId>
-      <version>2.1.2.Final</version>
+      <version>2.3.0.Final</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
Supersedes #24 (thanks @famod for the example :) )

Fixes #19.

Version bump to 1.1.0 relates to #21.