### PR TITLE
Update to Jandex 2.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.jboss.jandex</groupId>
   <artifactId>jandex-maven-plugin</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Jandex wrapper for Maven</name>
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>jandex</artifactId>
-      <version>2.3.1.Final</version>
+      <version>2.4.0.Final</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Also bump the minor version, as Jandex 2.4.0.Final has some bigger
changes (3 new methods in `IndexView`, new storage format version).