### PR TITLE
add IT to check if jandex.idx is stable between 2 runs: it is not

### DIFF
--- a/src/it/reproducible/invoker.properties
+++ b/src/it/reproducible/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean test
+
+invoker.goals.2 = test -DindexName=jandex-2.idx

--- a/src/it/reproducible/pom.xml
+++ b/src/it/reproducible/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss</groupId>
+    <artifactId>jboss-parent</artifactId>
+    <version>14</version>
+  </parent>
+
+  <groupId>org.jboss.jandex</groupId>
+  <artifactId>jandex-maven-plugin-reproducible</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <indexName>jandex.idx</indexName>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+            <configuration>
+              <indexName>${indexName}</indexName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/BasicAnnotation.java
+++ b/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/BasicAnnotation.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.jandex.maven.reproducible;
+
+import java.io.Serializable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+
+public class BasicAnnotation {
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface FieldAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ParameterAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TestAnnotation {
+        String name();
+        int[] ints();
+        String other() default "something";
+        String override() default "override-me";
+
+        long longValue();
+        Class<?> klass();
+        NestedAnnotation nested();
+        ElementType[] enums();
+        NestedAnnotation[] nestedArray();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation1 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation2 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation3 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation4 {}
+
+    public @interface NestedAnnotation {
+        float value();
+    }
+
+    @TestAnnotation(name = "Test", override = "somethingelse", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+            @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public class DummyClass implements Serializable {
+        void doSomething(int x, long y, Long foo){}
+        void doSomething(int x, long y){}
+
+        @FieldAnnotation
+        private int x;
+
+        @MethodAnnotation1
+        @MethodAnnotation2
+        @MethodAnnotation4
+        void doSomething(int x, long y, String foo){}
+
+        public class Nested {
+            public Nested(int noAnnotation) {}
+            public Nested(@ParameterAnnotation byte annotated) {}
+        }
+    }
+
+    public enum Enum {
+        A(1), B(2);
+
+        private Enum(int noAnnotation) {}
+        private Enum(@ParameterAnnotation byte annotated) {}
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedA implements Serializable {
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedB implements Serializable {
+
+        NestedB(Integer foo) {
+        }
+    }
+
+    public static class NestedC implements Serializable {
+    }
+
+    public class NestedD implements Serializable {
+    }
+
+    public static class NoEnclosureAnonTest {
+        static Class<?> anonymousStaticClass;
+        Class<?> anonymousInnerClass;
+
+        static {
+            anonymousStaticClass = new Object() {}.getClass();
+        }
+        {
+            anonymousInnerClass = new Object() {}.getClass();
+        }
+    }
+
+    public static class ApiClass {
+        public static void superApi() {}
+    }
+
+    public static class ApiUser {
+        public void f() {
+            ApiClass.superApi();
+        }
+    }
+}

--- a/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/BasicAnnotation2.java
+++ b/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/BasicAnnotation2.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.jandex.maven.reproducible;
+
+import java.io.Serializable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+
+public class BasicAnnotation2 {
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface FieldAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ParameterAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TestAnnotation {
+        String name();
+        int[] ints();
+        String other() default "something";
+        String override() default "override-me";
+
+        long longValue();
+        Class<?> klass();
+        NestedAnnotation nested();
+        ElementType[] enums();
+        NestedAnnotation[] nestedArray();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation1 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation2 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation3 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation4 {}
+
+    public @interface NestedAnnotation {
+        float value();
+    }
+
+    @TestAnnotation(name = "Test", override = "somethingelse", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+            @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public class DummyClass implements Serializable {
+        void doSomething(int x, long y, Long foo){}
+        void doSomething(int x, long y){}
+
+        @FieldAnnotation
+        private int x;
+
+        @MethodAnnotation1
+        @MethodAnnotation2
+        @MethodAnnotation4
+        void doSomething(int x, long y, String foo){}
+
+        public class Nested {
+            public Nested(int noAnnotation) {}
+            public Nested(@ParameterAnnotation byte annotated) {}
+        }
+    }
+
+    public enum Enum {
+        A(1), B(2);
+
+        private Enum(int noAnnotation) {}
+        private Enum(@ParameterAnnotation byte annotated) {}
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedA implements Serializable {
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedB implements Serializable {
+
+        NestedB(Integer foo) {
+        }
+    }
+
+    public static class NestedC implements Serializable {
+    }
+
+    public class NestedD implements Serializable {
+    }
+
+    public static class NoEnclosureAnonTest {
+        static Class<?> anonymousStaticClass;
+        Class<?> anonymousInnerClass;
+
+        static {
+            anonymousStaticClass = new Object() {}.getClass();
+        }
+        {
+            anonymousInnerClass = new Object() {}.getClass();
+        }
+    }
+
+    public static class ApiClass {
+        public static void superApi() {}
+    }
+
+    public static class ApiUser {
+        public void f() {
+            ApiClass.superApi();
+        }
+    }
+}

--- a/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/sub/SubAnnotation.java
+++ b/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/sub/SubAnnotation.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.jandex.maven.reproducible.sub;
+
+import java.io.Serializable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+
+public class SubAnnotation {
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface FieldAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ParameterAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TestAnnotation {
+        String name();
+        int[] ints();
+        String other() default "something";
+        String override() default "override-me";
+
+        long longValue();
+        Class<?> klass();
+        NestedAnnotation nested();
+        ElementType[] enums();
+        NestedAnnotation[] nestedArray();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation1 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation2 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation3 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation4 {}
+
+    public @interface NestedAnnotation {
+        float value();
+    }
+
+    @TestAnnotation(name = "Test", override = "somethingelse", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+            @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public class DummyClass implements Serializable {
+        void doSomething(int x, long y, Long foo){}
+        void doSomething(int x, long y){}
+
+        @FieldAnnotation
+        private int x;
+
+        @MethodAnnotation1
+        @MethodAnnotation2
+        @MethodAnnotation4
+        void doSomething(int x, long y, String foo){}
+
+        public class Nested {
+            public Nested(int noAnnotation) {}
+            public Nested(@ParameterAnnotation byte annotated) {}
+        }
+    }
+
+    public enum Enum {
+        A(1), B(2);
+
+        private Enum(int noAnnotation) {}
+        private Enum(@ParameterAnnotation byte annotated) {}
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedA implements Serializable {
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedB implements Serializable {
+
+        NestedB(Integer foo) {
+        }
+    }
+
+    public static class NestedC implements Serializable {
+    }
+
+    public class NestedD implements Serializable {
+    }
+
+    public static class NoEnclosureAnonTest {
+        static Class<?> anonymousStaticClass;
+        Class<?> anonymousInnerClass;
+
+        static {
+            anonymousStaticClass = new Object() {}.getClass();
+        }
+        {
+            anonymousInnerClass = new Object() {}.getClass();
+        }
+    }
+
+    public static class ApiClass {
+        public static void superApi() {}
+    }
+
+    public static class ApiUser {
+        public void f() {
+            ApiClass.superApi();
+        }
+    }
+}

--- a/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/sub/SubAnnotation2.java
+++ b/src/it/reproducible/src/main/java/org/jboss/jandex/maven/reproducible/sub/SubAnnotation2.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.jandex.maven.reproducible.sub;
+
+import java.io.Serializable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+
+public class SubAnnotation2 {
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface FieldAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ParameterAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TestAnnotation {
+        String name();
+        int[] ints();
+        String other() default "something";
+        String override() default "override-me";
+
+        long longValue();
+        Class<?> klass();
+        NestedAnnotation nested();
+        ElementType[] enums();
+        NestedAnnotation[] nestedArray();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation1 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation2 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation3 {}
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface MethodAnnotation4 {}
+
+    public @interface NestedAnnotation {
+        float value();
+    }
+
+    @TestAnnotation(name = "Test", override = "somethingelse", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+            @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public class DummyClass implements Serializable {
+        void doSomething(int x, long y, Long foo){}
+        void doSomething(int x, long y){}
+
+        @FieldAnnotation
+        private int x;
+
+        @MethodAnnotation1
+        @MethodAnnotation2
+        @MethodAnnotation4
+        void doSomething(int x, long y, String foo){}
+
+        public class Nested {
+            public Nested(int noAnnotation) {}
+            public Nested(@ParameterAnnotation byte annotated) {}
+        }
+    }
+
+    public enum Enum {
+        A(1), B(2);
+
+        private Enum(int noAnnotation) {}
+        private Enum(@ParameterAnnotation byte annotated) {}
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedA implements Serializable {
+    }
+
+    @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
+        @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
+    public static class NestedB implements Serializable {
+
+        NestedB(Integer foo) {
+        }
+    }
+
+    public static class NestedC implements Serializable {
+    }
+
+    public class NestedD implements Serializable {
+    }
+
+    public static class NoEnclosureAnonTest {
+        static Class<?> anonymousStaticClass;
+        Class<?> anonymousInnerClass;
+
+        static {
+            anonymousStaticClass = new Object() {}.getClass();
+        }
+        {
+            anonymousInnerClass = new Object() {}.getClass();
+        }
+    }
+
+    public static class ApiClass {
+        public static void superApi() {}
+    }
+
+    public static class ApiUser {
+        public void f() {
+            ApiClass.superApi();
+        }
+    }
+}

--- a/src/it/reproducible/verify.groovy
+++ b/src/it/reproducible/verify.groovy
@@ -1,0 +1,10 @@
+def jandexFile = new File(basedir, 'target/classes/META-INF/jandex.idx')
+def jandexFile2 = new File(basedir, 'target/classes/META-INF/jandex-2.idx')
+
+assert jandexFile.exists() : "File does not exist: ${jandexFile}"
+assert jandexFile2.exists() : "File does not exist: ${jandexFile}"
+
+byte[] idx = jandexFile.bytes
+byte[] idx2 = jandexFile2.bytes
+
+assert idx == idx2


### PR DESCRIPTION
working on Reproducible Builds, I proposed #26 to improve reproducibility
but after testing in real world projects using jandex-maven-plugin, I found that this is not sufficient: jandex.idx is not reproducible, and it does not seem to be only because of the plugin but directly the index creation.
A quick look at its indexer shows that it heavily uses HashMaps, which is typically something that is not reproducible. There may be many changes to do to the indexer.

I got to the conclusion that first step is to have an IT that checks if generated index is stable over 2 local runs or not: it will be a simple way to measure progress.
Ideally, it should be IMHO a unit test in Jandex indexer codebase, but I could not figure out how to do that UT: it was a lot easier for me to write the test as a jandex-maven-plugin IT.

Of course, this PR is not ready for merge because as explained in the intro, currently the IT fails which proves jandex.idx is not reproducible: I'll try to debug what is not stable in the indexer...